### PR TITLE
Fix type casting

### DIFF
--- a/common.go
+++ b/common.go
@@ -113,4 +113,4 @@ func convertToGoSlice(ptr **C.gchar, length int) []string {
 	return gostrings
 }
 
-var CLOCK_TIME_NONE = int64(C.GST_CLOCK_TIME_NONE)
+var CLOCK_TIME_NONE int64 = -1

--- a/element.go
+++ b/element.go
@@ -154,7 +154,7 @@ func (e *Element) AsElement() *Element {
 }
 
 func (e *Element) AsVideoOverlay() *VideoOverlay {
-	cVideoOverlay := C.toGstVideoOverlay(e.GetPtr())
+	cVideoOverlay := C.toGstVideoOverlay(C.gpointer(e.GetPtr()))
 	//defer C.free(unsafe.Pointer(cVideoOverlay))
 	goVideoOverlay := new(VideoOverlay)
 	goVideoOverlay.SetPtr(glib.Pointer(cVideoOverlay))

--- a/object.go
+++ b/object.go
@@ -153,7 +153,7 @@ A pointer to object .
 */
 func (o *GstObj) Ref(obj *GstObj) *GstObj {
 	r := new(GstObj)
-	r.SetPtr(glib.Pointer(C.gst_object_ref(o.g())))
+	r.SetPtr(glib.Pointer(C.gst_object_ref(C.gpointer(o.GetPtr()))))
 	return r
 }
 
@@ -163,7 +163,7 @@ This function does not take the lock on object as it relies on atomic refcountin
 The unref method should never be called with the LOCK held since this might deadlock the dispose function.
 */
 func (o *GstObj) Unref() {
-	C.gst_object_unref(o.g())
+	C.gst_object_unref(C.gpointer(o.GetPtr()))
 }
 
 /**
@@ -174,7 +174,7 @@ If the object is not floating, then this call adds a new normal reference increa
 */
 func (o *GstObj) RefSink(obj *GstObj) *GstObj {
 	r := new(GstObj)
-	r.SetPtr(glib.Pointer(C.gst_object_ref_sink(o.g())))
+	r.SetPtr(glib.Pointer(C.gst_object_ref_sink(C.gpointer(o.GetPtr()))))
 	return r
 }
 


### PR DESCRIPTION
If you try to compile gst/glib on a modern system you will get compilation error:
```
./common.go:116: constant 18446744073709551615 overflows int64
./element.go:157: cannot use e.GstObj.Object.GetPtr() (type glib.Pointer) as type C.gpointer in argument to func literal
./object.go:156: cannot use o.g() (type *C.struct__GstObject) as type C.gpointer in argument to func literal
./object.go:166: cannot use o.g() (type *C.struct__GstObject) as type C.gpointer in argument to func literal
./object.go:177: cannot use o.g() (type *C.struct__GstObject) as type C.gpointer in argument to func literal
```

I've added additional type casting for these pointers. Also I manually defined a CLOCK_TIME_NONE constant because on different systems the behavior of uint64(-1) is different.